### PR TITLE
Fix variable names for `instance?`

### DIFF
--- a/docfiles/cljs.core/instanceQMARK.md
+++ b/docfiles/cljs.core/instanceQMARK.md
@@ -8,6 +8,6 @@ see also:
 
 ## Details
 
-Returns true if `o` is an instance of type `t`, false otherwise.
+Returns true if `x` is an instance of type `c`, false otherwise.
 
 ## Examples


### PR DESCRIPTION
Apparently the parameter names used for [`instance?`](https://cljs.github.io/api/cljs.core/instanceQMARK) changed at some point, since the names used in the docs (`t` and `o`) match neither the function definition nor source docstring (`c` and `x`).