### PR TITLE
Align var-names in docs with displayed method signature

### DIFF
--- a/docfiles/cljs.core/instanceQMARK.md
+++ b/docfiles/cljs.core/instanceQMARK.md
@@ -8,6 +8,6 @@ see also:
 
 ## Details
 
-Returns true if `o` is an instance of type `t`, false otherwise.
+Returns true if `x` is an instance of type `c`, false otherwise.
 
 ## Examples


### PR DESCRIPTION
This aligns the variable names in *Details* with the displayed method signature.

---
I guess the method signature always use variable names from the code, so still brittle. But since the order of arguments always confuses me for this particular function, I thought I'd update the docs.